### PR TITLE
Corrected typo where published_at value is spelt incorrectly

### DIFF
--- a/components/post/default.htm
+++ b/components/post/default.htm
@@ -6,5 +6,5 @@
     {% for category in blogPost.categories %}
         <a href="{{ blogCategoryPage|page({'slug': category.slug}) }}">{{ category.name }}</a>{% if not loop.last %}, {% endif %}
     {% endfor %}
-    on {{ blogPost.publshed_at|date('M d, Y') }}
+    on {{ blogPost.published_at|date('M d, Y') }}
 </p>


### PR DESCRIPTION
This Caused todays date to be used instead of the actual published_at date.
