### PR TITLE
Fix for change to php-markdown

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -80,7 +80,7 @@ class Plugin extends PluginBase
             if (!$preview)
                 return $input;
 
-            return preg_replace('|\<img alt="([0-9]+)" src="image" \/>|m', 
+            return preg_replace('|\<img src="image" alt="([0-9]+)"([^>]*)\/>|m',
                 '<span class="image-placeholder" data-index="$1">
                     <span class="dropzone">
                         <span class="label">Click or drop an image...</span>


### PR DESCRIPTION
This little change should make the blog plugin compatible with the changes in the following pull request: [Change to PHP-Markdown](https://github.com/octobercms/library/pull/11)

This allows the adding of classes and ids via [Markdown Extra](http://michelf.ca/projects/php-markdown/extra/)
