### PR TITLE
Update create_posts_content_html.php

### DIFF
--- a/updates/create_posts_content_html.php
+++ b/updates/create_posts_content_html.php
@@ -10,7 +10,7 @@ class CreatePostsContentHtml extends Migration
     {
         Schema::table('rainlab_blog_posts', function($table)
         {
-            $table->text('content_html');
+            $table->text('content_html')->nullable();
         });
     }
 


### PR DESCRIPTION
As of current cli build 10:40AM CST - May 19-2014:
RainLab blog wont install due to required nullable on content_html.

Adding nullable fixes the problem.
