### PR TITLE
Allow post list to be ordered

### DIFF
--- a/components/Posts.php
+++ b/components/Posts.php
@@ -46,6 +46,12 @@ class Posts extends ComponentBase
      */
     public $categoryPage;
 
+    /**
+     * If the post list should be ordered by another attribute.
+     * @var string
+     */
+    public $postOrderAttr;
+
     public function componentDetails()
     {
         return [
@@ -82,6 +88,12 @@ class Posts extends ComponentBase
                 'type'         => 'string',
                 'default'      => 'No posts found'
             ],
+            'postOrderAttr' => [
+                'title'       => 'Post order',
+                'description' => 'Attribute on which the posts should be ordered',
+                'type'        => 'dropdown',
+                'default'     => 'published_at asc'
+            ],
             'categoryPage' => [
                 'title'       => 'Category page',
                 'description' => 'Name of the category page file for the "Posted into" category links. This property is used by the default component partial.',
@@ -107,6 +119,11 @@ class Posts extends ComponentBase
     public function getPostPageOptions()
     {
         return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    public function getPostOrderAttrOptions()
+    {
+        return BlogPost::$allowedSortingOptions;
     }
 
     public function onRun()
@@ -142,7 +159,7 @@ class Posts extends ComponentBase
          */
         $posts = BlogPost::with('categories')->listFrontEnd([
             'page'       => $this->propertyOrParam('pageParam'),
-            'sort'       => ['published_at', 'updated_at'],
+            'sort'       => $this->property('postOrderAttr'),
             'perPage'    => $this->property('postsPerPage'),
             'categories' => $categories
         ]);

--- a/models/Post.php
+++ b/models/Post.php
@@ -29,6 +29,21 @@ class Post extends Model
      */
     protected $dates = ['published_at'];
 
+    /**
+     * The attributes on which the post list can be ordered
+     * @var array
+     */
+    public static $allowedSortingOptions = array(
+        'title asc' => 'Title asc',
+        'title desc' => 'Title desc',
+        'created_at asc' => 'Created asc',
+        'created_at desc' => 'Created desc',
+        'updated_at asc' => 'Updated asc',
+        'updated_at desc' => 'Updated desc',
+        'published_at asc' => 'Published asc',
+        'published_at desc' => 'Published desc',
+    );
+
     /*
      * Relations
      */
@@ -71,7 +86,6 @@ class Post extends Model
             'published'  => true
         ], $options));
 
-        $allowedSortingOptions = ['created_at', 'updated_at', 'published_at'];
         $searchableFields = ['title', 'slug', 'excerpt', 'content'];
 
         App::make('paginator')->setCurrentPage($page);
@@ -85,12 +99,13 @@ class Post extends Model
         if (!is_array($sort)) $sort = [$sort];
         foreach ($sort as $_sort) {
 
-            $parts = explode(' ', $_sort);
-            if (count($parts) < 2) array_push($parts, 'desc');
-            list($sortField, $sortDirection) = $parts;
+            if (in_array($_sort, array_keys(self::$allowedSortingOptions))) {
+                $parts = explode(' ', $_sort);
+                if (count($parts) < 2) array_push($parts, 'desc');
+                list($sortField, $sortDirection) = $parts;
 
-            if (in_array($sortField, $allowedSortingOptions))
-                $query->orderBy($_sort, 'desc');
+                $query->orderBy($sortField, $sortDirection);
+            }
         }
 
         /*


### PR DESCRIPTION
Now posts can be ordered or on title, or on created_at, or on
updated_at or on published_at
