### PR TITLE
Fixes issue 47 (https://github.com/rainlab/blog-plugin/issues/47)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -89,13 +89,16 @@ class Plugin extends PluginBase
             if (!$preview)
                 return $input;
 
-            return preg_replace('|\<img alt="([0-9]+)" src="image"([^>]*)\/>|m',
+            // No indentation in the replacement pattern to prevent
+            // ParseDown from parsing the code as a blockquote.
+
+            return preg_replace('|\!\[([0-9]+)\]\(image\)|m',
                 '<span class="image-placeholder" data-index="$1">
-                    <span class="upload-dropzone">
-                        <span class="label">Click or drop an image...</span>
-                        <span class="indicator"></span>
-                    </span>
-                </span>',
+<span class="upload-dropzone">
+<span class="label">Click or drop an image...</span>
+<span class="indicator"></span>
+</span>
+</span>',
             $input);
         });
     }

--- a/models/Post.php
+++ b/models/Post.php
@@ -146,12 +146,14 @@ class Post extends Model
 
     public static function formatHtml($input, $preview = false)
     {
-        $result = Markdown::parse(trim($input));
+        $result = trim($input);
+
+        $result = TagProcessor::instance()->processTags($result, $preview);
+
+        $result = Markdown::parse($result);
 
         if ($preview)
             $result = str_replace('<pre>', '<pre class="prettyprint">', $result);
-
-        $result = TagProcessor::instance()->processTags($result, $preview);
 
         return $result;
     }


### PR DESCRIPTION
Intead of letting Parsedown interpret the shortcuts for inserting
images via Dropzone (e.g. ![1](image)), we parse them ourselves
before passing the input over to Parsedown.

Note: Classes and id:s can't be added with the MarkdownExtra
syntax as in the documentation. These have to be added *after*
the acutal image upload has been made. This is actually also
the case with the existing code, and should either be fixed or
mentioned in the documentation.