### PR TITLE
Enable default Sorting Post.featured_images by sort_order

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -58,7 +58,7 @@ class Post extends Model
     ];
 
     public $attachMany = [
-        'featured_images' => ['System\Models\File'],
+        'featured_images' => ['System\Models\File', 'order' => 'sort_order'],
         'content_images' => ['System\Models\File']
     ];
 


### PR DESCRIPTION
Maybe it`s a good idea to sort images by sort_order by default, so users can sort images in the backend by dragging them.