### PR TITLE
Fix grouping Error (at least with PostgreSQL) when viewing Blog->Categories

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -168,6 +168,7 @@ class Post extends Model
         return $query
             ->whereNotNull('published')
             ->where('published', true)
+            ->groupBy('published_at')
         ;
     }
 

--- a/models/Post.php
+++ b/models/Post.php
@@ -168,7 +168,7 @@ class Post extends Model
         return $query
             ->whereNotNull('published')
             ->where('published', true)
-            ->groupBy('published_at')
+            ->groupBy('published_at', 'id')
         ;
     }
 


### PR DESCRIPTION
SQLSTATE[42803]: Grouping error: 7 ERROR: column "rainlab_blog_posts.published_at" must appear in the GROUP BY clause or be used in an aggregate function LINE 1: ...lished" is not null and "published" = $2 order by "published... ^ (SQL: select count(*) as aggregate from "rainlab_blog_posts" inner join "rainlab_blog_posts_categories" on "rainlab_blog_posts"."id" = "rainlab_blog_posts_categories"."post_id" where "rainlab_blog_posts_categories"."category_id" = 1 and "published" is not null and "published" = 1 order by "published_at" desc)