### PR TITLE
Fix init post-form.js

### DIFF
--- a/assets/js/post-form.js
+++ b/assets/js/post-form.js
@@ -6,14 +6,17 @@
 
         this.formAction = this.$form.attr('action')
         this.sessionKey = $('input[name=_session_key]', this.$form).val()
-        this.codeEditor = this.$markdownEditor.markdownEditor('getEditorObject')
+        if ( null != this.$markdownEditor.markdownEditor ) {
+            this.codeEditor = this.$markdownEditor.markdownEditor('getEditorObject')
 
-        this.$markdownEditor.on('oc.markdownEditorInitPreview', $.proxy(this.initPreview, this))
+            this.$markdownEditor.on('oc.markdownEditorInitPreview', $.proxy(this.initPreview, this))
 
-        this.initDropzones()
-        this.initFormEvents()
+            this.initDropzones()
+            this.initFormEvents()
+            this.addToolbarButton()
+        }
+
         this.initLayout()
-        this.addToolbarButton()
     }
 
     PostForm.prototype.addToolbarButton = function() {


### PR DESCRIPTION
When you change type content block from `RainLab\Blog\FormWidgets\BlogMarkdown` to `richeditor`, post-form.js started to thrown some errors, because it expect markdown editor.

Solution is add one condition: "If there is no MD editor, then no JS init needed."

But `initLayout()` is important for nice layout:

with `initLayout()`:

![snimek obrazovky 2015-08-11 v 11 35 36](https://cloud.githubusercontent.com/assets/374917/9194608/cc782e08-401c-11e5-8310-5ac62cff84e9.png)

without `initLayout()`:

![snimek obrazovky 2015-08-11 v 11 35 59](https://cloud.githubusercontent.com/assets/374917/9194618/d38b817c-401c-11e5-9e19-e7064c12f4cb.png)