### PR TITLE
Allows to restrict possibility to publish posts to specific users/groups

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -35,7 +35,9 @@ class Plugin extends PluginBase
             'rainlab.blog.access_posts'         => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab.blog::lang.blog.access_posts'],
             'rainlab.blog.access_categories'    => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab.blog::lang.blog.access_categories'],
             'rainlab.blog.access_other_posts'   => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab.blog::lang.blog.access_other_posts'],
-            'rainlab.blog.access_import_export' => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab.blog::lang.blog.access_import_export']
+            'rainlab.blog.access_import_export' => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab.blog::lang.blog.access_import_export'],
+            // A new permission for restricting access  to publish posts
+            'rainlab.blog.access_publish'       => ['tab' => 'rainlab.blog::lang.blog.tab', 'label' => 'rainlab_blog::lang.blog.access_publish']
         ];
     }
 

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -16,6 +16,8 @@ return [
         'access_posts' => 'Blog Artikel verwalten',
         'access_categories' => 'Blog Kategorien verwalten',
         'access_other_posts' => 'Blog Artikel anderer Benutzer verwalten',
+        // A new permission for restricting access to publishing
+        'access_publish' => 'Kann Artikel veröffentlichen',
         'delete_confirm' => 'Bist du sicher?',
         'chart_published' => 'Veröffentlicht',
         'chart_drafts' => 'Entwurf',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -17,6 +17,8 @@ return [
         'access_categories' => 'Manage the blog categories',
         'access_other_posts' => 'Manage other users blog posts',
         'access_import_export' => 'Allowed to import and export posts',
+        // A new permission for restricting access to publishing
+        'access_publish' => 'Can publish posts?',
         'delete_confirm' => 'Are you sure?',
         'chart_published' => 'Published',
         'chart_drafts' => 'Drafts',

--- a/models/Post.php
+++ b/models/Post.php
@@ -260,4 +260,26 @@ class Post extends Model
 
         return Str::limit(Html::strip($this->content_html), 600);
     }
+    
+    /** 
+     * A new function to limit visibility of the published-button
+     * @return boolean
+    */
+    public function filterFields($fields, $context = null)
+    {
+        // Get the current logged on user to see if author or not.
+        $user = BackendAuth::getUser();
+        if(!$user->hasAnyAccess(["rainlab.blog.access_publish"]))
+        {
+            $fields->published->hidden = true;
+            $fields->published_at->hidden = true;
+            return false;
+        }
+        else
+        {
+            $fields->published->hidden = false;
+            $fields->published_at->hidden = false;
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
I added support to restrict the access to the publish fields for users and groups. Access can be granted by administrators via the backend panel (manage groups/authors). I thought that should be necessary, as we for instance manage a multi-user online-magazine and needed the option to prevent our "normal" authors from publishing probably unauthorized stuff that we needed to edit before.

I also added language support for english and german.

P.S.: I'm new to github, so I hope I managed it to follow the rules for contributing – if not please just tell me! :)