### PR TITLE
Move hardcoded summary options to configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ The component can be used on any page, it will hijack the entire page cycle to d
     ==
     <!-- This markup will never be displayed -->
 
+
+## Configuration
+
+To overwrite the default configuration create a `config/rainlab/blog/config.php`. You can return only values you want to override.
+
+### Summary
+
+A summary attribute is generated for each post.
+
+If you enter an excerpt manually, it gets used as summary. Alternatively, you can use the `summary_separator` (default is `<!-- more -->`) to mark the end of the summary. If a post contains no separator, the text gets truncated after the number of characters specified in `summary_default_length` (default is 600 characters).
+
+
 ## Markdown guide
 
 October supports [standard markdown syntax](http://daringfireball.net/projects/markdown/) as well as [extended markdown syntax](http://michelf.ca/projects/php-markdown/extra/)

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'summary_separator' => '<!-- more -->',
+    'summary_default_length' => 600
+];

--- a/models/Post.php
+++ b/models/Post.php
@@ -349,7 +349,8 @@ class Post extends Model
         }
 
         $length = Config::get('rainlab.blog::summary_default_length', 600);
-        return Str::limit(Html::strip($this->content_html), $length);
+
+        return Html::limit($this->content_html, $length);
     }
 
     //

--- a/models/Post.php
+++ b/models/Post.php
@@ -3,6 +3,7 @@
 use Db;
 use Url;
 use App;
+use Config;
 use Str;
 use Html;
 use Lang;
@@ -317,12 +318,13 @@ class Post extends Model
      */
     public function getHasSummaryAttribute()
     {
-        $more = '<!-- more -->';
+        $more   = Config::get('rainlab.blog::summary_separator', '<!-- more -->');
+        $length = Config::get('rainlab.blog::summary_default_length', 600);
 
         return (
             !!strlen(trim($this->excerpt)) ||
             strpos($this->content_html, $more) !== false ||
-            strlen(Html::strip($this->content_html)) > 600
+            strlen(Html::strip($this->content_html)) > $length
         );
     }
 
@@ -340,13 +342,14 @@ class Post extends Model
             return $excerpt;
         }
 
-        $more = '<!-- more -->';
+        $more = Config::get('rainlab.blog::summary_separator', '<!-- more -->');
         if (strpos($this->content_html, $more) !== false) {
             $parts = explode($more, $this->content_html);
             return array_get($parts, 0);
         }
 
-        return Html::limit($this->content_html, 600);
+        $length = Config::get('rainlab.blog::summary_default_length', 600);
+        return Str::limit(Html::strip($this->content_html), $length);
     }
 
     //


### PR DESCRIPTION
The summary separator and default length are currently hardcoded in the `Post` model. 

Sometimes it's necessary to have a post summary shorter than the default 600 chars without having to manually add the separator or write an excerpt.

I have created a config file with two new options `summary_separator` and `summary_default_length`. This makes the summary generation a bit more dynamic.
