### PR TITLE
Set published_at datepicker widget mode to datetime

### DIFF
--- a/models/post/fields.yaml
+++ b/models/post/fields.yaml
@@ -50,7 +50,7 @@ secondaryTabs:
             span: left
             cssClass: checkbox-align
             type: datepicker
-            mode: date
+            mode: datetime
             trigger:
                 action: enable
                 field: published


### PR DESCRIPTION
Right now datepicker for published_at field works in date mode which leads to issues like #43 It's because when time is not set, all posts get 00:00:00 as published_at time and it will mess up the sorting.
So if we just change datepicker mode to datetime, we'll be able to set published time. It will help sorting posts and the best thing is that it won't affect people who don't need time field because it's totally optional (if you won't fill it, you'd still get those 00:00:00).