### PR TITLE
getHasSummaryAttribute method always true bug fix

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -275,6 +275,6 @@ class Post extends Model
             return array_get($parts, 0);
         }
 
-        return Str::limit(Html::strip($this->content_html), 600);
+        return $this->content_html;
     }
 }


### PR DESCRIPTION
`getHasSummaryAttribute()` method is always true and you can't check if post has summary or not. So if there is no `$excerpt`  or `<!-- more -->` tag `getSummaryAttribute()` now  returns just `content_html` 