### PR TITLE
added afterDelete() method to delete attached pictures, translatable fields

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -34,6 +34,10 @@ class Category extends Model
         ]
     ];
 
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+
+    public $translatable = ['name'];
+
     public function beforeValidate()
     {
         // Generate a URL slug for this model

--- a/models/Post.php
+++ b/models/Post.php
@@ -79,7 +79,7 @@ class Post extends Model
 
     public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
 
-    public $translatable = ['title', 'content'];
+    public $translatable = ['title', 'content', 'content_html'];
 
     public function afterValidate()
     {

--- a/models/Post.php
+++ b/models/Post.php
@@ -77,6 +77,10 @@ class Post extends Model
 
     public $preview = null;
 
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+
+    public $translatable = ['title', 'content'];
+
     public function afterValidate()
     {
         if ($this->published && !$this->published_at) {

--- a/models/Post.php
+++ b/models/Post.php
@@ -91,6 +91,17 @@ class Post extends Model
         $this->content_html = self::formatHtml($this->content);
     }
 
+
+    public function afterDelete()
+    {
+        $this->featured_images->each(function($model) {
+            $model->delete();
+        });
+        $this->content_images->each(function($model) {
+            $model->delete();
+        });
+    }
+
     /**
      * Sets the "url" attribute with a URL to this object
      * @param string $pageName


### PR DESCRIPTION
Deleting posts was leaving the uploaded attachments in the system_files table and in the storage/app/uploads folder. Since post-attachments is OneToMany relation, those children should be deleted on parent delete.