### PR TITLE
Fix Class BlogCategory not found exception in RSS component

### DIFF
--- a/components/RssFeed.php
+++ b/components/RssFeed.php
@@ -5,6 +5,7 @@ use Redirect;
 use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
+use RainLab\Blog\Models\Category as BlogCategory;
 
 class RssFeed extends ComponentBase
 {


### PR DESCRIPTION
Hello and congratulations on the first stable release!

## Problem
When using RSS feed component and category slug parameter is set like this: 
`{{ :category }}`
with page url being /:category/rss.xml, it will produce an exception:
```
Class 'RainLab\Blog\Components\BlogCategory' not found
/var/www/plugins/rainlab/blog/components/RssFeed.php line 134
```

## Solution
Aliasing Category model as BlogCategory solves the issue. 
It seems like the use operator was there but got lost for some reason.