### PR TITLE
Expose year, month and day of post published_at value to be used in URL

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -118,6 +118,13 @@ class Post extends Model
             $params['category'] = $this->categories->count() ? $this->categories->first()->slug : null;
         }
 
+        //expose published year, month and day as URL parameters
+        if ($this->published) {
+            $params['year'] = $this->published_at->format('Y');
+            $params['month'] = $this->published_at->format('m');
+            $params['day'] = $this->published_at->format('d');
+        }
+
         return $this->url = $controller->pageUrl($pageName, $params);
     }
 


### PR DESCRIPTION
Hello,

I'm migrating my blog to October and all my posts have urls like `/2016/07/04/post-title`. To make such urls possible for Blog posts, we need to expose additional url parameters in `Post::setUrl()` method. This pull request do just that.