### PR TITLE
Add option to hide category post count

### DIFF
--- a/components/Categories.php
+++ b/components/Categories.php
@@ -54,6 +54,12 @@ class Categories extends ComponentBase
                 'default'     => 'blog/category',
                 'group'       => 'Links',
             ],
+            'hidePostCount' => [
+                'title'       => 'rainlab.blog::lang.settings.category_hide_post_count',
+                'description' => 'rainlab.blog::lang.settings.category_hide_post_count_description',
+                'type'        => 'checkbox',
+                'default'     => 0
+            ],
         ];
     }
 
@@ -67,6 +73,7 @@ class Categories extends ComponentBase
         $this->currentCategorySlug = $this->page['currentCategorySlug'] = $this->property('slug');
         $this->categoryPage = $this->page['categoryPage'] = $this->property('categoryPage');
         $this->categories = $this->page['categories'] = $this->loadCategories();
+        $this->hidePostCount = $this->page['hidePostCount'] = $this->property('hidePostCount');
     }
 
     protected function loadCategories()

--- a/components/Categories.php
+++ b/components/Categories.php
@@ -47,18 +47,18 @@ class Categories extends ComponentBase
                 'type'        => 'checkbox',
                 'default'     => 0
             ],
+            'hidePostCount' => [
+                'title'       => 'rainlab.blog::lang.settings.category_hide_post_count',
+                'description' => 'rainlab.blog::lang.settings.category_hide_post_count_description',
+                'type'        => 'checkbox',
+                'default'     => 0
+            ],
             'categoryPage' => [
                 'title'       => 'rainlab.blog::lang.settings.category_page',
                 'description' => 'rainlab.blog::lang.settings.category_page_description',
                 'type'        => 'dropdown',
                 'default'     => 'blog/category',
                 'group'       => 'Links',
-            ],
-            'hidePostCount' => [
-                'title'       => 'rainlab.blog::lang.settings.category_hide_post_count',
-                'description' => 'rainlab.blog::lang.settings.category_hide_post_count_description',
-                'type'        => 'checkbox',
-                'default'     => 0
             ],
         ];
     }
@@ -73,7 +73,7 @@ class Categories extends ComponentBase
         $this->currentCategorySlug = $this->page['currentCategorySlug'] = $this->property('slug');
         $this->categoryPage = $this->page['categoryPage'] = $this->property('categoryPage');
         $this->categories = $this->page['categories'] = $this->loadCategories();
-        $this->hidePostCount = $this->page['hidePostCount'] = $this->property('hidePostCount');
+        $this->hidePostCount = $this->page['hidePostCount'] = ($this->property('hidePostCount') == 1);
     }
 
     protected function loadCategories()

--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -3,7 +3,7 @@
         {% partial __SELF__ ~ "::items"
             categories = __SELF__.categories
             currentCategorySlug = __SELF__.currentCategorySlug
-            hidePostCount = __SELF__.hidePostCount
+            hidePostCount = hidePostCount
         %}
     </ul>
 {% endif %}

--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -3,6 +3,7 @@
         {% partial __SELF__ ~ "::items"
             categories = __SELF__.categories
             currentCategorySlug = __SELF__.currentCategorySlug
+            hidePostCount = __SELF__.hidePostCount
         %}
     </ul>
 {% endif %}

--- a/components/categories/items.htm
+++ b/components/categories/items.htm
@@ -2,7 +2,7 @@
     {% set postCount = category.post_count %}
     <li {% if category.slug == currentCategorySlug %}class="active"{% endif %}>
         <a href="{{ category.url }}">{{ category.name }}</a>
-        {% if !hidePostCount && postCount %}
+        {% if not hidePostCount and postCount %}
             <span class="badge">{{ postCount }}</span>
         {% endif %}
 
@@ -11,7 +11,7 @@
                 {% partial __SELF__ ~ "::items"
                     categories=category.children
                     currentCategorySlug=currentCategorySlug
-                    hidePostCount = __SELF__.hidePostCount
+                    hidePostCount=hidePostCount
                 %}
             </ul>
         {% endif %}

--- a/components/categories/items.htm
+++ b/components/categories/items.htm
@@ -1,8 +1,8 @@
 {% for category in categories %}
     {% set postCount = category.post_count %}
     <li {% if category.slug == currentCategorySlug %}class="active"{% endif %}>
-        <a href="{{ category.url }}">{{ category.name }}</a> 
-        {% if postCount %}
+        <a href="{{ category.url }}">{{ category.name }}</a>
+        {% if !hidePostCount && postCount %}
             <span class="badge">{{ postCount }}</span>
         {% endif %}
 
@@ -11,6 +11,7 @@
                 {% partial __SELF__ ~ "::items"
                     categories=category.children
                     currentCategorySlug=currentCategorySlug
+                    hidePostCount = __SELF__.hidePostCount
                 %}
             </ul>
         {% endif %}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -83,6 +83,8 @@ return [
         'category_display_empty_description' => 'Show categories that do not have any posts.',
         'category_page' => 'Category page',
         'category_page_description' => 'Name of the category page file for the category links. This property is used by the default component partial.',
+        'category_hide_post_count' => 'Hide category post count',
+        'category_hide_post_count_description' => 'Don\'t show the numbers of posts in a category next to the category name.',
         'post_title' => 'Post',
         'post_description' => 'Displays a blog post on the page.',
         'post_slug' => 'Post slug',

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -80,6 +80,8 @@ return [
         'category_display_empty_description' => 'Geef categorieën weer die geen artikelen hebben.',
         'category_page' => 'Categorie pagina',
         'category_page_description' => 'Naam van categorie pagina bestand voor de categorie links. Deze waarde wordt standaard gebruikt door de partial.',
+        'category_hide_post_count' => 'Verberg aantal posts',
+        'category_hide_post_count_description' => 'Verberg het aantal posts in een categorie naast de naam van de categorie.',
         'post_title' => 'Artikel',
         'post_description' => 'Geef een artikel weer op de pagina.',
         'post_slug' => 'Artikel slug',


### PR DESCRIPTION
 I added a property to the category list module to hide the post count of a category next to the name.

![image](https://cloud.githubusercontent.com/assets/3493941/17139345/55b4ab52-5344-11e6-99e5-7889b638b50f.png)
