### PR TITLE
create partial output for Instant Article Facebook RSS Feed

### DIFF
--- a/components/RssFeed.php
+++ b/components/RssFeed.php
@@ -16,6 +16,11 @@ class RssFeed extends ComponentBase
     public $posts;
 
     /**
+     * init variable for rssTemplate
+     */
+    public $rssTemplate;
+
+    /**
      * If the post list should be filtered by a category, the model to use.
      * @var Model
      */
@@ -71,6 +76,13 @@ class RssFeed extends ComponentBase
                 'default'     => 'blog/post',
                 'group'       => 'Links',
             ],
+            'rssTemplate' => [
+                'title'       => 'RSS Template',
+                'type'        => 'dropdown',
+                'options'     => ['@default'=>'Default', '@default-ia'=>'Instant Article'],
+                'default'     => 'default',
+                'group'       => 'Template',
+            ],
         ];
     }
 
@@ -88,7 +100,7 @@ class RssFeed extends ComponentBase
     {
         $this->prepareVars();
 
-        $xmlFeed = $this->renderPartial('@default');
+        $xmlFeed = $this->renderPartial($this->property('rssTemplate'));
 
         return Response::make($xmlFeed, '200')->header('Content-Type', 'text/xml');
     }

--- a/components/rssfeed/default-ia.htm
+++ b/components/rssfeed/default-ia.htm
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+    xmlns:atom="http://www.w3.org/2005/Atom"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>{{ this.page.meta_title ?: this.page.title }}</title>
+        <link>{{ link }}</link>
+
+        <description>{{ this.page.meta_description ? : 'Blog Feed' }}</description>
+        <atom:link href="{{ rssLink }}" rel="self" type="application/rss+xml" />
+        {% for post in posts %}
+        <item>
+            <title>{{ post.title }}</title>
+            <link>{{ post.url }}</link>
+            <pubDate>{{ post.published_at|date('Y-m-d') }}</pubDate>
+            <content:encoded><![CDATA[ <header><figure data-mode="fullscreen"><img src="{{ post.featured_images.first.getThumb(800, 400, 'crop') }}" /></figure></header> {{ post.content_html|raw }} ]]></content:encoded>
+        </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
already use this plugin for some of my team projects, this is really cool. Just curious with [Facebook Instant Article](https://developers.facebook.com/docs/instant-articles), they create a cool reading platform inside. Of course This is the only one (the best) blogs plugin  on Octobercms.

So [Facebook Instant Article RSS](https://developers.facebook.com/docs/instant-articles/publishing/setup-rss-feed) have a little bit different code with yours (The Facebook xml code is `<content:encoded>` and yours `<content>`), and i already did that for my current projects.
