### PR TITLE
Support multisite for blog-plugin

### DIFF
--- a/components/Posts.php
+++ b/components/Posts.php
@@ -5,7 +5,6 @@ use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
 use RainLab\Blog\Models\Category as BlogCategory;
-use Request;
 
 class Posts extends ComponentBase
 {
@@ -164,7 +163,6 @@ class Posts extends ComponentBase
          * List all the posts, eager load their categories
          */
         $posts = BlogPost::with('categories')
-        ->where('domain', Request::getHost())
         ->listFrontEnd([
             'page'       => $this->property('pageNumber'),
             'sort'       => $this->property('sortOrder'),

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -5,6 +5,7 @@ use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
 use RainLab\Blog\Models\Category as BlogCategory;
+use Request;
 
 class Posts extends ComponentBase
 {
@@ -162,7 +163,9 @@ class Posts extends ComponentBase
         /*
          * List all the posts, eager load their categories
          */
-        $posts = BlogPost::with('categories')->listFrontEnd([
+        $posts = BlogPost::with('categories')
+        ->where('domain', Request::getHost())
+        ->listFrontEnd([
             'page'       => $this->property('pageNumber'),
             'sort'       => $this->property('sortOrder'),
             'perPage'    => $this->property('postsPerPage'),

--- a/components/RssFeed.php
+++ b/components/RssFeed.php
@@ -6,7 +6,6 @@ use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
 use RainLab\Blog\Models\Category as BlogCategory;
-use Request;
 
 class RssFeed extends ComponentBase
 {
@@ -124,7 +123,6 @@ class RssFeed extends ComponentBase
          * List all the posts, eager load their categories
          */
         $posts = BlogPost::with('categories')
-        ->where('domain', Request::getHost())
         ->listFrontEnd([
             'sort'       => $this->property('sortOrder'),
             'perPage'    => $this->property('postsPerPage'),

--- a/components/RssFeed.php
+++ b/components/RssFeed.php
@@ -6,6 +6,7 @@ use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
 use RainLab\Blog\Models\Category as BlogCategory;
+use Request;
 
 class RssFeed extends ComponentBase
 {
@@ -122,7 +123,9 @@ class RssFeed extends ComponentBase
         /*
          * List all the posts, eager load their categories
          */
-        $posts = BlogPost::with('categories')->listFrontEnd([
+        $posts = BlogPost::with('categories')
+        ->where('domain', Request::getHost())
+        ->listFrontEnd([
             'sort'       => $this->property('sortOrder'),
             'perPage'    => $this->property('postsPerPage'),
             'category'   => $category

--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -60,10 +60,9 @@ class Posts extends Controller
 
     public function listExtendQuery($query)
     {
+        $query->where('domain', Request::getHost());
         if (!$this->user->hasAnyAccess(['rainlab.blog.access_other_posts'])) {
-            $query
-                ->where('user_id', $this->user->id)
-                ->where('domain', Request::getHost());
+            $query->where('user_id', $this->user->id);
         }
     }
 

--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -6,6 +6,7 @@ use BackendMenu;
 use Backend\Classes\Controller;
 use ApplicationException;
 use RainLab\Blog\Models\Post;
+use Request;
 
 class Posts extends Controller
 {
@@ -30,8 +31,8 @@ class Posts extends Controller
 
     public function index()
     {
-        $this->vars['postsTotal'] = Post::count();
-        $this->vars['postsPublished'] = Post::isPublished()->count();
+        $this->vars['postsTotal'] = Post::where('domain', Request::getHost())->count();
+        $this->vars['postsPublished'] = Post::where('domain', Request::getHost())->isPublished()->count();
         $this->vars['postsDrafts'] = $this->vars['postsTotal'] - $this->vars['postsPublished'];
 
         $this->asExtension('ListController')->index();
@@ -60,7 +61,9 @@ class Posts extends Controller
     public function listExtendQuery($query)
     {
         if (!$this->user->hasAnyAccess(['rainlab.blog.access_other_posts'])) {
-            $query->where('user_id', $this->user->id);
+            $query
+                ->where('user_id', $this->user->id)
+                ->where('domain', Request::getHost());
         }
     }
 

--- a/models/Category.php
+++ b/models/Category.php
@@ -7,6 +7,7 @@ use RainLab\Blog\Models\Post;
 use October\Rain\Router\Helper as RouterHelper;
 use Cms\Classes\Page as CmsPage;
 use Cms\Classes\Theme;
+use Request;
 
 class Category extends Model
 {
@@ -57,7 +58,7 @@ class Category extends Model
 
     public function getPostCountAttribute()
     {
-        return $this->posts()->count();
+        return $this->posts()->where('domain', Request::getHost())->count();
     }
 
     /**

--- a/models/Post.php
+++ b/models/Post.php
@@ -192,6 +192,8 @@ class Post extends Model
 
         $searchableFields = ['title', 'slug', 'excerpt', 'content'];
 
+        $query->where('domain', Request::getHost());
+
         if ($published) {
             $query->isPublished();
         }

--- a/models/Post.php
+++ b/models/Post.php
@@ -12,6 +12,7 @@ use RainLab\Blog\Classes\TagProcessor;
 use Backend\Models\User;
 use Carbon\Carbon;
 use DB;
+use Request;
 
 class Post extends Model
 {
@@ -102,6 +103,7 @@ class Post extends Model
     public function beforeSave()
     {
         $this->content_html = self::formatHtml($this->content);
+        $this->domain = Request::getHost();
     }
 
     /**

--- a/models/post/columns.yaml
+++ b/models/post/columns.yaml
@@ -4,6 +4,10 @@
 
 columns:
 
+    domain:
+        label: rainlab.blog::lang.post.author_email
+        invisible: true
+
     title:
         label: rainlab.blog::lang.post.title
         searchable: true

--- a/updates/create_posts_table.php
+++ b/updates/create_posts_table.php
@@ -13,6 +13,7 @@ class CreatePostsTable extends Migration
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('user_id')->unsigned()->nullable()->index();
+            $table->string('domain')->nullable();
             $table->string('title')->nullable();
             $table->string('slug')->index();
             $table->text('excerpt')->nullable();


### PR DESCRIPTION
Blog-plugin now work with multisite. Every blog is stored with a domain (where the admin is working on). On public site, only display the blog of current domain only.

Code changes:
- add column: domain
- before save: Request.getHost
- query: where(domain, Request.getHost)