### PR TITLE
Resolve conflict b/w filterFields & repeater

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -312,13 +312,21 @@ class Post extends Model
     {
         $user = BackendAuth::getUser();
 
-        if (!$user->hasAnyAccess(["rainlab.blog.access_publish"])) {
-            $fields->published->hidden = true;
-            $fields->published_at->hidden = true;
+         if (!$user->hasAnyAccess(["rainlab.blog.access_publish"])) {
+        	if(isset($fields->published)) {
+            	$fields->published->hidden = true;
+        	}
+        	if(isset($fields->published_at)) {
+            	$fields->published_at->hidden = true;
+        	}
         }
         else {
-            $fields->published->hidden = false;
-            $fields->published_at->hidden = false;
+        	if(isset($fields->published)) {
+        		$fields->published->hidden = false;
+        	}
+        	if(isset($fields->published_at)) {
+        		$fields->published_at->hidden = false;
+        	}
         }
     }
 }


### PR DESCRIPTION
When a repeater field is used with a filterfields method defined, adding a new item to the repeater throws an error:

`"Creating default object from empty value" on line 320 of /plugins/rainlab/blog/models/Post.php`

The isset can resolve the exception.

```
    public function filterFields($fields, $context = null)
    {
        $user = BackendAuth::getUser();
         if (!$user->hasAnyAccess(["rainlab.blog.access_publish"])) {
            if(isset($fields->published)) {
                $fields->published->hidden = true;
            }
            if(isset($fields->published_at)) {
                $fields->published_at->hidden = true;
            }
        }
        else {
            if(isset($fields->published)) {
                $fields->published->hidden = false;
            }
            if(isset($fields->published_at)) {
                $fields->published_at->hidden = false;
            }
        }
    }
```
