### PR TITLE
Added featured image/thumbnail for a blog post from the Media Manager

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -57,6 +57,7 @@ return [
         'excerpt' => 'Excerpt',
         'summary' => 'Summary',
         'featured_images' => 'Featured Images',
+        'blog_image_thumbnail' => 'Blog Image Thumbnail',
         'delete_confirm' => 'Delete this post?',
         'close_confirm' => 'The post is not saved.',
         'return_to_posts' => 'Return to posts list'

--- a/models/post/fields.yaml
+++ b/models/post/fields.yaml
@@ -69,3 +69,9 @@ secondaryTabs:
             mode: image
             imageWidth: 200
             imageHeight: 200
+
+        blog_image_thumbnail:
+            tab: rainlab.blog::lang.post.tab_manage
+            label: rainlab.blog::lang.post.blog_image_thumbnail
+            type: mediafinder
+            mode: image

--- a/updates/update_thumbnail.php
+++ b/updates/update_thumbnail.php
@@ -1,0 +1,26 @@
+<?php namespace RainLab\Blog\Updates;
+
+use Schema;
+use DbDongle;
+use October\Rain\Database\Updates\Migration;
+
+class UpdateThumbnail extends Migration
+{
+
+    public function up()
+    {
+        Schema::table('rainlab_blog_posts', function($table)
+        {
+            $table->text('blog_image_thumbnail')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('rainlab_blog_posts', function($table)
+        {
+            $table->dropColumn('blog_image_thumbnail');
+        });
+    }
+
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -39,3 +39,6 @@
 1.2.12: Description field added to category form.
 1.2.13: Improved support for Static Pages menus, added a blog post and all blog posts.
 1.2.14: Added post exception property to the post list component, useful for showing related posts.
+1.2.15:
+    - Added thumbnail image for the blog post
+    - update_thumbnail.php


### PR DESCRIPTION
This is will add a new field for the blog post to handle a image dedicated to it from the Media Manager, works better than featured image option.