### PR TITLE
Static Pages menu - blog category item "Allow nested items" always generates full category tree instead of just the category referenced

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -205,7 +205,7 @@ class Category extends Model
             $result['mtime'] = $category->updated_at;
 
             if ($item->nesting) {
-                $categories = $category->getNested();
+                $categories = $category->getAllChildren()->toNested(false);
                 $iterator = function($categories) use (&$iterator, &$item, &$theme, $url) {
                     $branch = [];
 


### PR DESCRIPTION
As the title says, Static Pages menu - blog category item "Allow nested items" always generates full category tree instead of just the category referenced. 

This is because getNested() creates a new query without scope. By calling getAllChildren() to get the children of the referenced category and manually calling toNested with false to allow orphans (because the parent category is not available in the children collection) you get what's expected.