### PR TITLE
Make pages.menuitem aware of if blog post is published

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -372,7 +372,9 @@ class Post extends Model
             $references = [];
             $posts = self::orderBy('title')->get();
             foreach ($posts as $post) {
-                $references[$post->id] = $post->title;
+                if(!is_null($post->published) && $post->published == true) {
+                    $references[$post->id] = $post->title;
+                }    
             }
 
             $result = [
@@ -461,15 +463,17 @@ class Post extends Model
 
             $posts = self::orderBy('title')->get();
             foreach ($posts as $post) {
-                $postItem = [
-                    'title' => $post->title,
-                    'url'   => self::getPostPageUrl($item->cmsPage, $post, $theme),
-                    'mtime' => $post->updated_at,
-                ];
+                if(!is_null($post->published) && $post->published == true) {
+                    $postItem = [
+                        'title' => $post->title,
+                        'url'   => self::getPostPageUrl($item->cmsPage, $post, $theme),
+                        'mtime' => $post->updated_at,
+                    ];
 
-                $postItem['isActive'] = $postItem['url'] == $url;
+                    $postItem['isActive'] = $postItem['url'] == $url;
 
-                $result['items'][] = $postItem;
+                    $result['items'][] = $postItem;
+                }
             }
         }
 


### PR DESCRIPTION
This is a fix for Issue #271.

Making pages.menuitem.resolveItem and pages.menuitem.getTypeInfo aware
of the fact that blog posts are not always published. In the event a
post is not published, they should not be returned.