### PR TITLE
Add public method to get prev and next post

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -55,13 +55,33 @@ class Post extends ComponentBase
 
     protected function loadPost()
     {
+        return $this->getPost();
+    }
+
+    public function getPrevPost()
+    {
+        return $this->getPost('<');
+    }
+
+    public function getNextPost()
+    {
+        return $this->getPost('>');
+    }
+
+    private function getPost($operator = null)
+    {
         $slug = $this->property('slug');
 
         $post = new BlogPost;
 
-        $post = $post->isClassExtendedWith('RainLab.Translate.Behaviors.TranslatableModel')
-            ? $post->transWhere('slug', $slug)
-            : $post->where('slug', $slug);
+        if ($operator) {
+            $post = $post->where('id', $operator, $this->post->id)->orderBy('id', $operator == '>' ? 'asc' : 'desc');
+        }
+        else {
+            $post = $post->isClassExtendedWith('RainLab.Translate.Behaviors.TranslatableModel')
+                ? $post->transWhere('slug', $slug)
+                : $post->where('slug', $slug);
+        }
 
         $post = $post->isPublished()->first();
 


### PR DESCRIPTION
Hi @daftspunk,

I think it will be useful if we can load prev and next post. So we can get it by `{{ blogPost.getPrevPost() }}` and `{{ blogPost.getNextPost() }}`. I thought it's a good practice to make it as methods which mean it can reduce the query if we don't use it.

Thanks