### PR TITLE
Added more params to url generation for sitemap

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -501,7 +501,13 @@ class Post extends Model
         }
 
         $paramName = substr(trim($matches[1]), 1);
-        $url = CmsPage::url($page->getBaseFileName(), [$paramName => $category->slug]);
+        $params = [
+            $paramName => $category->slug,
+            'year' => $category->published_at->format('Y'),
+            'month' => $category->published_at->format('m'),
+            'day' => $category->published_at->format('d'),
+        ];
+        $url = CmsPage::url($page->getBaseFileName(), $params);
 
         return $url;
     }


### PR DESCRIPTION
Hello

When Sitemap is generated with all-blog-posts included, posts are getting wrong urls if year, month or day params are used in post urls generation (see Post::setUrl() method). That is because these params are not passed to url() method in case of Sitemap generation. This PR proposes a fix for that.