### PR TITLE
Update Post.php so unfound slug redirects to a 404

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -73,6 +73,11 @@ class Post extends ComponentBase
                 $category->setUrl($this->categoryPage, $this->controller);
             });
         }
+        
+        if (!$post || !$post->exists) {
+            $this->setStatusCode(404);
+            return $this->controller->run('404');
+        }
 
         return $post;
     }


### PR DESCRIPTION
Unfound blog post slugs redirect to a /404 route. Without this, the Forum plugin's embedTopic component could create topics for non-existent blog posts..