### PR TITLE
Fix an issue where a post is not pulled when the slug is set via a component's attribute #322

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -51,6 +51,10 @@ class Post extends ComponentBase
     public function onRun()
     {
         $this->categoryPage = $this->page['categoryPage'] = $this->property('categoryPage');
+    }
+
+    public function onRender()
+    {
         $this->post = $this->page['post'] = $this->loadPost();
     }
 


### PR DESCRIPTION
Use case: Displaying the latest blog post on the page when no slug is set.
This minor change will allow this:

```
title = "News"
url = "/news/:slug?"
layout = "default"
is_hidden = 0

[blogPosts]
pageNumber = "{{ :page }}"
categoryFilter = "news"
postsPerPage = 10
noPostsMessage = "No items found."
sortOrder = "published_at desc"
categoryPage = 404
postPage = "news"

[blogPost]
slug = "{{ :slug }}"

[blogPost firstPost]
==
{% if not this.param.slug %}
	{% component 'firstPost' slug=blogPosts.posts[0].slug %}
{% else %}
	{% component 'blogPost' %}
{% endif %}
```

For use case details and reasons why it didn't work up to date, see #322. 
