### PR TITLE
Fixes issues #326 and #335 introduced with #324

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -51,11 +51,14 @@ class Post extends ComponentBase
     public function onRun()
     {
         $this->categoryPage = $this->page['categoryPage'] = $this->property('categoryPage');
+        $this->post = $this->page['post'] = $this->loadPost();
     }
 
     public function onRender()
     {
-        $this->post = $this->page['post'] = $this->loadPost();
+        if( empty( $this->post ) ) {
+            $this->post = $this->page['post'] = $this->loadPost();
+        }
     }
 
     protected function loadPost()

--- a/components/Post.php
+++ b/components/Post.php
@@ -56,7 +56,7 @@ class Post extends ComponentBase
 
     public function onRender()
     {
-        if( empty( $this->post ) ) {
+        if (empty($this->post)) {
             $this->post = $this->page['post'] = $this->loadPost();
         }
     }


### PR DESCRIPTION
This fix returns post retrieval logic back to onRun() method and adds a
condition to retrieve post in onRender() method if none exists to allow
manually set component’s property (eg. {% component ‘blogPost’ slug =
‘my-slug’ %} ).