### PR TITLE
Category Filter for blogPost component

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -99,6 +99,7 @@ return [
         'post_slug_description' => "Look up the blog post using the supplied slug value.",
         'post_category' => 'Category page',
         'post_category_description' => 'Name of the category page file for the category links. This property is used by the default component partial.',
+        'post_filter_description' => 'Select a category to filter the posts by. Leave empty to show all posts.',
         'posts_title' => 'Post List',
         'posts_description' => 'Displays a list of latest blog posts on the page.',
         'posts_pagination' => 'Page number',


### PR DESCRIPTION
Just like #365, When you want to use blog plugin for services page (Custom page for services category), the page that you are using to show services posts shows other blog posts too (other than posts that in services category).

For example, assume that we have 'Web Design' blog post in services category and 'First blog post' in general category.

/services/web-desing/
/services/first-blog-post/

Will both work without category filter.