### PR TITLE
Add twig filters to default.htm and items.htm

### DIFF
--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -1,8 +1,10 @@
-{% if __SELF__.categories %}
+{% if __SELF__.categories|length > 0 %}
     <ul class="category-list">
         {% partial __SELF__ ~ "::items"
             categories = __SELF__.categories
             currentCategorySlug = __SELF__.currentCategorySlug
         %}
     </ul>
+{% else %}
+    <p>No categories were found.</p>
 {% endif %}

--- a/components/categories/items.htm
+++ b/components/categories/items.htm
@@ -6,7 +6,7 @@
             <span class="badge">{{ postCount }}</span>
         {% endif %}
 
-        {% if category.children %}
+        {% if category.children|length > 0 %}
             <ul>
                 {% partial __SELF__ ~ "::items"
                     categories=category.children


### PR DESCRIPTION
Supersedes #355

- Add twig filters to remove empty markup for default.htm and items.htm
- Add default paragraph markup when no categories are found in default.htm