### PR TITLE
Make migrations a bit safer

### DIFF
--- a/updates/create_categories_table.php
+++ b/updates/create_categories_table.php
@@ -34,8 +34,8 @@ class CreateCategoriesTable extends Migration
 
     public function down()
     {
-        Schema::drop('rainlab_blog_categories');
-        Schema::drop('rainlab_blog_posts_categories');
+        Schema::dropIfExists('rainlab_blog_categories');
+        Schema::dropIfExists('rainlab_blog_posts_categories');
     }
 
 }

--- a/updates/create_posts_table.php
+++ b/updates/create_posts_table.php
@@ -26,7 +26,7 @@ class CreatePostsTable extends Migration
 
     public function down()
     {
-        Schema::drop('rainlab_blog_posts');
+        Schema::dropIfExists('rainlab_blog_posts');
     }
 
 }


### PR DESCRIPTION
Most down methods use `dropIfExists` (see [user](https://github.com/rainlab/user-plugin/blob/master/updates/create_users_table.php#L31), [translate](https://github.com/rainlab/translate-plugin/blob/master/updates/create_locales_table.php#L24), [notify](https://github.com/rainlab/notify-plugin/blob/master/updates/create_notifications_table.php#L26), etc...). Using `drop` as we currently are is causing problems with unit testing another plugin that extends this one.