### PR TITLE
Feature/#393 - Fixed Post random order

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -242,21 +242,16 @@ class Post extends Model
         /*
          * Sorting
          */
-        if (!is_array($sort)) {
-            $sort = [$sort];
-        }
+        if (in_array($sort, array_keys(self::$allowedSortingOptions))) {
+            if ($sort == 'random') {
+                $query->inRandomOrder();
+            } else {
+                @list($sortField, $sortDirection) = explode(' ', $sort);
 
-        foreach ($sort as $_sort) {
+                if (is_null($sortDirection)) {
+                    $sortDirection = "desc";
+                }
 
-            if (in_array($_sort, array_keys(self::$allowedSortingOptions))) {
-                $parts = explode(' ', $_sort);
-                if (count($parts) < 2) {
-                    array_push($parts, 'desc');
-                }
-                list($sortField, $sortDirection) = $parts;
-                if ($sortField == 'random') {
-                    $sortField = Db::raw('RAND()');
-                }
                 $query->orderBy($sortField, $sortDirection);
             }
         }

--- a/models/Post.php
+++ b/models/Post.php
@@ -242,7 +242,7 @@ class Post extends Model
         /*
          * Sorting
          */
-        if (in_array($sort, array_keys(self::$allowedSortingOptions))) {
+        if (in_array($sort, array_keys(static::$allowedSortingOptions))) {
             if ($sort == 'random') {
                 $query->inRandomOrder();
             } else {


### PR DESCRIPTION
Fixes #393.

Usage of "@" is justified here because we just need to suppress an expected warning for an empty "direction" part which may be skipped due to `listFrontend` scope usage.

`@list($sortField, $sortDirection) = explode(' ', $sort);`