### PR TITLE
Remove check for category relation

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -151,9 +151,7 @@ class Post extends Model
             'slug' => $this->slug,
         ];
 
-        if (array_key_exists('categories', $this->getRelations())) {
-            $params['category'] = $this->categories->count() ? $this->categories->first()->slug : null;
-        }
+        $params['category'] = $this->categories->count() ? $this->categories->first()->slug : null;
 
         //expose published year, month and day as URL parameters
         if ($this->published) {


### PR DESCRIPTION
The categories relation should always exist, as it is defined in the same model. However, the ``getRelations()`` method appears to be buggy, as it does not return all defined relations. For example when I install the ``Bedard.BlogTags`` plugin, this will cover all other relations and only the newly added ``tags`` relation is beein returned.