### PR TITLE
Importing posts does not assign the selected categories

### DIFF
--- a/models/PostImport.php
+++ b/models/PostImport.php
@@ -29,7 +29,7 @@ class PostImport extends ImportModel
         return AuthorModel::all()->lists('full_name', 'email');
     }
 
-    public function getPostCategoriesOptions()
+    public function getCategoriesOptions()
     {
         return Category::lists('name', 'id');
     }

--- a/models/postimport/fields.yaml
+++ b/models/postimport/fields.yaml
@@ -18,7 +18,7 @@ fields:
         default: true
         span: right
 
-    post_categories:
+    categories:
         label: Categories
         commentAbove: Select the categories that imported posts will belong to (optional).
         type: checkboxlist


### PR DESCRIPTION
Importing posts with the option "Create categories specified in the import file" unchecked and selecting some categories that imported posts will belong to, the table rainlab_blog_posts_categories is not populated