### PR TITLE
Fix incorrect use of validation for exceptPost component property

### DIFF
--- a/components/Posts.php
+++ b/components/Posts.php
@@ -113,8 +113,6 @@ class Posts extends ComponentBase
                 'title'             => 'rainlab.blog::lang.settings.posts_except_post',
                 'description'       => 'rainlab.blog::lang.settings.posts_except_post_description',
                 'type'              => 'string',
-                'validationPattern' => 'string',
-                'validationMessage' => 'rainlab.blog::lang.settings.posts_except_post_validation',
                 'default'           => '',
                 'group'             => 'rainlab.blog::lang.settings.group_exceptions',
             ],


### PR DESCRIPTION
A regEx validation pattern of `'string'` makes any legitimate use of the `excerptPost` property in the Posts component invalid. Also a localisation string for `rainlab.blog::lang.settings.posts_except_post_validation` doesn't exist.