### PR TITLE
Allow to (optionally) disable the visibility of unpublished posts in the frontend to backend users

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -34,6 +34,10 @@ class Plugin extends PluginBase
     public function registerPermissions()
     {
         return [
+            'rainlab.blog.access_blog' => [
+                'tab'   => 'rainlab.blog::lang.blog.tab',
+                'label' => 'rainlab.blog::lang.blog.access_blog'
+            ],
             'rainlab.blog.access_posts' => [
                 'tab'   => 'rainlab.blog::lang.blog.tab',
                 'label' => 'rainlab.blog::lang.blog.access_posts'
@@ -88,6 +92,22 @@ class Plugin extends PluginBase
                         'permissions' => ['rainlab.blog.access_categories']
                     ]
                 ]
+            ]
+        ];
+    }
+
+    public function registerSettings()
+    {
+        return [
+            'blog' => [
+                'label' => 'rainlab.blog::lang.blog.menu_label',
+                'description' => 'rainlab.blog::lang.blog.settings_description',
+                'category' => 'Blog',
+                'icon' => 'icon-pencil',
+                'class' => 'RainLab\Blog\Models\Settings',
+                'order' => 500,
+                'keywords' => 'blog post category',
+                'permissions' => ['rainlab.blog.access_blog']
             ]
         ];
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -34,9 +34,9 @@ class Plugin extends PluginBase
     public function registerPermissions()
     {
         return [
-            'rainlab.blog.access_blog' => [
+            'rainlab.blog.manage_settings' => [
                 'tab'   => 'rainlab.blog::lang.blog.tab',
-                'label' => 'rainlab.blog::lang.blog.access_blog'
+                'label' => 'rainlab.blog::lang.blog.manage_settings'
             ],
             'rainlab.blog.access_posts' => [
                 'tab'   => 'rainlab.blog::lang.blog.tab',
@@ -102,12 +102,12 @@ class Plugin extends PluginBase
             'blog' => [
                 'label' => 'rainlab.blog::lang.blog.menu_label',
                 'description' => 'rainlab.blog::lang.blog.settings_description',
-                'category' => 'Blog',
+                'category' => 'rainlab.blog::lang.blog.menu_label',
                 'icon' => 'icon-pencil',
                 'class' => 'RainLab\Blog\Models\Settings',
                 'order' => 500,
                 'keywords' => 'blog post category',
-                'permissions' => ['rainlab.blog.access_blog']
+                'permissions' => ['rainlab.blog.manage_settings']
             ]
         ];
     }

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -7,6 +7,7 @@ use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
 use RainLab\Blog\Models\Category as BlogCategory;
+use RainLab\Blog\Models\Settings as BlogSettings;
 
 class Posts extends ComponentBase
 {
@@ -237,6 +238,6 @@ class Posts extends ComponentBase
     {
         $backendUser = BackendAuth::getUser();
 
-        return $backendUser && $backendUser->hasAccess('rainlab.blog.access_posts');
+        return $backendUser && $backendUser->hasAccess('rainlab.blog.access_posts') && BlogSettings::get('show_all_posts', true);
     }
 }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -18,7 +18,7 @@ return [
         'access_other_posts' => 'Manage other users blog posts',
         'access_import_export' => 'Allowed to import and export posts',
         'access_publish' => 'Allowed to publish posts',
-        'access_blog' => 'Manage blog settings',
+        'manage_settings' => 'Manage blog settings',
         'delete_confirm' => 'Are you sure?',
         'chart_published' => 'Published',
         'chart_drafts' => 'Drafts',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -18,10 +18,16 @@ return [
         'access_other_posts' => 'Manage other users blog posts',
         'access_import_export' => 'Allowed to import and export posts',
         'access_publish' => 'Allowed to publish posts',
+        'access_blog' => 'Manage blog settings',
         'delete_confirm' => 'Are you sure?',
         'chart_published' => 'Published',
         'chart_drafts' => 'Drafts',
-        'chart_total' => 'Total'
+        'chart_total' => 'Total',
+        'settings_description' => 'Manage blog settings',
+        'show_all_posts_label' => 'Show all posts to backend users',
+        'show_all_posts_comment' => 'Display both published and unpublished posts on the frontend to backend users',
+        'tab_general' => 'General'
+
     ],
     'posts' => [
         'list_title' => 'Manage the blog posts',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,18 @@
+<?php namespace RainLab\Blog\Models;
+
+use October\Rain\Database\Model;
+
+class Settings extends Model
+{
+    use \October\Rain\Database\Traits\Validation;
+
+    public $implement = ['System.Behaviors.SettingsModel'];
+
+    public $settingsCode = 'rainlab_blog_settings';
+
+    public $settingsFields = 'fields.yaml';
+
+    public $rules = [
+        'show_all_posts' => ['boolean'],
+    ];
+}

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,0 +1,9 @@
+tabs:
+    fields:
+        show_all_posts:
+            span: left
+            label: rainlab.blog::lang.blog.show_all_posts_label
+            comment: rainlab.blog::lang.blog.show_all_posts_comment
+            type: switch
+            default: 1
+            tab: rainlab.blog::lang.blog.tab_general


### PR DESCRIPTION
As it stands now, there is no way to disable the visibility of unpublished posts in the frontend to backend users. This can sometimes be confusing to content creators and should be optional.

This pull request creates a settings view for the blog plugin with a switch to disable this functionality. The change is backwards compatible because in the absence of user preference the default is to show both published and unpublished posts which is the current functionality.

**To clarify**, this change only affects backend users with the permission to access blog posts.

Only the `posts` component is affected because this feature is only useful while displaying lists of blog posts.