### PR TITLE
change !== null to !empty

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -301,7 +301,7 @@ class Post extends Model
         /*
          * Except Categories
          */
-        if ($exceptCategories !== null) {
+        if (!empty($exceptCategories)) {
             $exceptCategories = is_array($exceptCategories) ? $exceptCategories : [$exceptCategories];
             array_walk($exceptCategories, 'trim');
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -49,3 +49,4 @@
     - posts_add_metadata.php
 1.3.1: Fixed metadata column not being jsonable
 1.3.2: Allow custom slug name for components, add 404 handling for missing blog posts, allow exporting of blog images.
+1.3.3: Skip subquery for excluding categories if property value is not set.


### PR DESCRIPTION
Here is the new PR with the bumped version number. 

We are having an issue with a recent update with the plugin. Regardless of what params are passed into the model the if at line 304 was always evaluated to true. This adds a sub query to the fetch that is about to happen. Also due to the fact that the nested true behavior is attached to the Category model the sub query has a "order by nest_left" to the subquery. This is not allowed in  mssql and we were getting the following error: 

SQLSTATE[42000]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified. (SQL: select count(*) as aggregate from [rainlab_blog_posts] where not exists (select * from [rainlab_blog_categories] inner join [rainlab_blog_posts_categories] on [rainlab_blog_categories].[id] = [rainlab_blog_posts_categories].[category_id] where [rainlab_blog_posts].[id] = [rainlab_blog_posts_categories].[post_id] and [slug] in () order by [nest_left] asc))

By making the following change as long as excluded Categories aren't needed then we can at least have the option of not attaching the sub query and it will work for us. I realize that this doesn't address the underlying issue of how to make this work even with excluded Categories. 

Regardless the calling logic will not pass in null ever,  so this makes it skip the sub query if its not needed.  

![order_issue_ms_sql](https://user-images.githubusercontent.com/22779816/58510174-6e0c1680-8155-11e9-8599-1cd16a167d0f.png)
