### PR TITLE
Fix issue #455

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -228,7 +228,6 @@ class Category extends Model
             $result['mtime'] = $category->updated_at;
 
             if ($item->nesting) {
-                $categories = $category->getNested();
                 $iterator = function($categories) use (&$iterator, &$item, &$theme, $url) {
                     $branch = [];
 
@@ -250,7 +249,7 @@ class Category extends Model
                     return $branch;
                 };
 
-                $result['items'] = $iterator($categories);
+                $result['items'] = $iterator($category->children);
             }
         }
         elseif ($item->type == 'all-blog-categories') {


### PR DESCRIPTION
This change fixes issue #455. The menu item will link to the *reference* as configured in the "Edit Menu Item" model. If `Allow Nested` is enabled, the menu item will have links to all descendants of the *reference* (and only children).