### PR TITLE
add flexibility to Post setUrl method

### DIFF
--- a/components/Posts.php
+++ b/components/Posts.php
@@ -221,7 +221,7 @@ class Posts extends ComponentBase
          * Add a "url" helper attribute for linking to each post and category
          */
         $posts->each(function($post) use ($categorySlug) {
-            $post->setUrl($this->postPage, $this->controller, ['category'=>$categorySlug]);
+            $post->setUrl($this->postPage, $this->controller, ['category' => $categorySlug]);
 
             $post->categories->each(function($category) {
                 $category->setUrl($this->categoryPage, $this->controller);

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -195,6 +195,7 @@ class Posts extends ComponentBase
     protected function listPosts()
     {
         $category = $this->category ? $this->category->id : null;
+        $categorySlug = $this->category ? $this->category->slug : null;
 
         /*
          * List all the posts, eager load their categories
@@ -219,8 +220,8 @@ class Posts extends ComponentBase
         /*
          * Add a "url" helper attribute for linking to each post and category
          */
-        $posts->each(function($post) {
-            $post->setUrl($this->postPage, $this->controller);
+        $posts->each(function($post) use ($categorySlug) {
+            $post->setUrl($this->postPage, $this->controller, ['category'=>$categorySlug]);
 
             $post->categories->each(function($category) {
                 $category->setUrl($this->categoryPage, $this->controller);

--- a/models/Post.php
+++ b/models/Post.php
@@ -152,17 +152,20 @@ class Post extends Model
      * Sets the "url" attribute with a URL to this object.
      * @param string $pageName
      * @param Controller $controller
+     * @param array $params Override request URL parameters
      *
      * @return string
      */
-    public function setUrl($pageName, $controller)
+    public function setUrl($pageName, $controller, $params = [])
     {
-        $params = [
-            'id'   => $this->id,
-            'slug' => $this->slug
-        ];
+        $category = $this->categories->count() ? $this->categories->first()->slug : null;
 
-        $params['category'] = $this->categories->count() ? $this->categories->first()->slug : null;
+        $params = array_merge( [
+            'id'        => $this->id,
+            'slug'      => $this->slug,
+            'category'  => $category,
+        ], $params);
+
 
         // Expose published year, month and day as URL parameters.
         if ($this->published) {

--- a/models/Post.php
+++ b/models/Post.php
@@ -166,7 +166,6 @@ class Post extends Model
             'category'  => $category,
         ], $params);
 
-
         // Expose published year, month and day as URL parameters.
         if ($this->published) {
             $params['year']  = $this->published_at->format('Y');

--- a/models/Post.php
+++ b/models/Post.php
@@ -160,7 +160,7 @@ class Post extends Model
     {
         $category = $this->categories->count() ? $this->categories->first()->slug : null;
 
-        $params = array_merge( [
+        $params = array_merge([
             'id'        => $this->id,
             'slug'      => $this->slug,
             'category'  => $category,

--- a/models/Post.php
+++ b/models/Post.php
@@ -158,13 +158,14 @@ class Post extends Model
      */
     public function setUrl($pageName, $controller, $params = [])
     {
-        $category = $this->categories->count() ? $this->categories->first()->slug : null;
-
         $params = array_merge([
             'id'       => $this->id,
             'slug'     => $this->slug,
-            'category' => $category,
         ], $params);
+
+        if (!$params['category']) {
+            $params['category'] = $this->categories->count() ? $this->categories->first()->slug : null;
+        }
 
         // Expose published year, month and day as URL parameters.
         if ($this->published) {

--- a/models/Post.php
+++ b/models/Post.php
@@ -159,8 +159,8 @@ class Post extends Model
     public function setUrl($pageName, $controller, $params = [])
     {
         $params = array_merge([
-            'id'       => $this->id,
-            'slug'     => $this->slug,
+            'id'   => $this->id,
+            'slug' => $this->slug,
         ], $params);
 
         if (!$params['category']) {

--- a/models/Post.php
+++ b/models/Post.php
@@ -161,9 +161,9 @@ class Post extends Model
         $category = $this->categories->count() ? $this->categories->first()->slug : null;
 
         $params = array_merge([
-            'id'        => $this->id,
-            'slug'      => $this->slug,
-            'category'  => $category,
+            'id'       => $this->id,
+            'slug'     => $this->slug,
+            'category' => $category,
         ], $params);
 
         // Expose published year, month and day as URL parameters.


### PR DESCRIPTION
The blogPosts component calls each posts setUrl() method but cannot provide the currently selected category.

this PR adds a $params array to allow overriding parameters when setting the post's URL.

the PR modifies the blogPosts component by passing the current category when setting each post's url.