### PR TITLE
prevent problems for URL parameter that do no exist in Post model

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -51,10 +51,16 @@ class Post extends ComponentBase
 
     public function init()
     {
-        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) {
+        $model = $this;
+        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) use ($model) {
             $newParams = $params;
 
             foreach ($params as $paramName => $paramValue) {
+                if (!Schema::hasColumn($model->table, $paramName)) {
+                    // skip non-existent parameters
+                    continue;
+                }
+
                 $records = BlogPost::transWhere($paramName, $paramValue, $oldLocale)->first();
 
                 if ($records) {

--- a/components/Post.php
+++ b/components/Post.php
@@ -55,7 +55,8 @@ class Post extends ComponentBase
             $newParams = $params;
 
             if (isset($params['slug'])) {
-                if ($records = BlogPost::transWhere('slug', $params['slug'], $oldLocale)->first()) {
+                $records = BlogPost::transWhere('slug', $params['slug'], $oldLocale)->first();
+                if ($records) {
                     $records->translateContext($newLocale);
                     $newParams['slug'] = $records['slug'];
                 }

--- a/components/Post.php
+++ b/components/Post.php
@@ -2,7 +2,6 @@
 
 use Event;
 use BackendAuth;
-use Schema;
 use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;
@@ -55,19 +54,15 @@ class Post extends ComponentBase
         Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) {
             $newParams = $params;
 
-            foreach ($params as $paramName => $paramValue) {
-                if (!Schema::hasColumn('rainlab_blog_posts', $paramName)) {
-                    // skip non-existent parameters
-                    continue;
-                }
-
-                $records = BlogPost::transWhere($paramName, $paramValue, $oldLocale)->first();
-
-                if ($records) {
+            if (isset($params['slug'])) {
+                $paramName = 'slug';
+                $paramValue = $params[$paramName];
+                if ($records = BlogPost::transWhere($paramName, $paramValue, $oldLocale)->first()) {
                     $records->translateContext($newLocale);
                     $newParams[$paramName] = $records[$paramName];
                 }
             }
+
             return $newParams;
         });
     }

--- a/components/Post.php
+++ b/components/Post.php
@@ -2,6 +2,7 @@
 
 use Event;
 use BackendAuth;
+use Schema;
 use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\Blog\Models\Post as BlogPost;

--- a/components/Post.php
+++ b/components/Post.php
@@ -55,11 +55,9 @@ class Post extends ComponentBase
             $newParams = $params;
 
             if (isset($params['slug'])) {
-                $paramName = 'slug';
-                $paramValue = $params[$paramName];
-                if ($records = BlogPost::transWhere($paramName, $paramValue, $oldLocale)->first()) {
+                if ($records = BlogPost::transWhere('slug', $params['slug'], $oldLocale)->first()) {
                     $records->translateContext($newLocale);
-                    $newParams[$paramName] = $records[$paramName];
+                    $newParams['slug'] = $records['slug'];
                 }
             }
 

--- a/components/Post.php
+++ b/components/Post.php
@@ -52,12 +52,11 @@ class Post extends ComponentBase
 
     public function init()
     {
-        $model = $this;
-        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) use ($model) {
+        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) {
             $newParams = $params;
 
             foreach ($params as $paramName => $paramValue) {
-                if (!Schema::hasColumn($model->table, $paramName)) {
+                if (!Schema::hasColumn('rainlab_blog_posts', $paramName)) {
                     // skip non-existent parameters
                     continue;
                 }


### PR DESCRIPTION
A page with the following URL using the BlogPost component will generate an SQL query error when switching locale since the rainlab_blog_posts DB table does not have a field calld `category`:

```
url = "/post/:slug/:category?"
```

