### PR TITLE
Revert Arrow Function Usage

### DIFF
--- a/components/post/default.htm
+++ b/components/post/default.htm
@@ -18,11 +18,13 @@
 
 <p class="info">
     {% if post.categories.count %}
-        {% set categoryLinks = post.categories | map(c => "<a href=\"#{c.url}\">#{c.name}</a>") | join(', ') %}
-
+        {% set categoryLinks = [] %}
+        {% for category in post.categories %}
+            {% set categoryLinks = categoryLinks|merge(["<a href=\"#{category.url}\">#{category.name}</a>"]) %}
+        {% endfor %}
         {{ 'rainlab.blog::lang.post.posted_byline' | trans({
             date: post.published_at | date('rainlab.blog::lang.post.date_format' | trans),
-            categories: categoryLinks
+            categories: categoryLinks | join(', ')
         }) }}
     {% else %}
         {{ 'rainlab.blog::lang.post.posted_byline_no_categories' | trans({

--- a/components/posts/default.htm
+++ b/components/posts/default.htm
@@ -7,11 +7,14 @@
 
             <p class="info">
                 {% if post.categories.count %}
-                    {% set categoryLinks = post.categories | map(c => "<a href=\"#{c.url}\">#{c.name}</a>") | join(', ') %}
+                    {% set categoryLinks = [] %}
+                    {% for category in post.categories %}
+                        {% set categoryLinks = categoryLinks|merge(["<a href=\"#{category.url}\">#{category.name}</a>"]) %}
+                    {% endfor %}
 
                     {{ 'rainlab.blog::lang.post.posted_byline' | trans({
                         date: post.published_at | date('rainlab.blog::lang.post.date_format' | trans),
-                        categories: categoryLinks
+                        categories: categoryLinks | join(', ')
                     }) }}
                 {% else %}
                     {{ 'rainlab.blog::lang.post.posted_byline_no_categories' | trans({


### PR DESCRIPTION
As of 1.4.1, arrow functions were introduced, which is a php 7.4
feature. However, the min php version is 7.0, and this causes issues
on implementations that have not yet updated to 7.4.

Fixes #537 