### PR TITLE
Ignore categories that do not contain published posts.

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -256,7 +256,7 @@ class Category extends Model
                 'items' => []
             ];
 
-            $categories = self::orderBy('name')->get();
+            $categories = self::has('posts')->orderBy('name')->get();
             foreach ($categories as $category) {
                 $categoryItem = [
                     'title' => $category->name,

--- a/models/Category.php
+++ b/models/Category.php
@@ -256,7 +256,11 @@ class Category extends Model
                 'items' => []
             ];
 
-            $categories = self::has('posts')->orderBy('name')->get();
+            $categories = self::select(self::query()->qualifyColumn('*'))
+                ->leftJoin(self::posts()->getTable(), self::posts()->getQualifiedParentKeyName(), '=', self::posts()->getQualifiedForeignPivotKeyName())
+                ->leftJoin(self::posts()->getRelated()->getTable(), self::posts()->qualifyColumn(self::posts()->getRelatedKeyName()), '=', self::posts()->getQualifiedRelatedPivotKeyName())
+                ->where(\Closure::fromCallable([new Post, 'scopeIsPublished']))->orderBy('name')->get();
+            
             foreach ($categories as $category) {
                 $categoryItem = [
                     'title' => $category->name,


### PR DESCRIPTION
Currently, categories without posts or with unpublished posts are included in menus (and consequently they are included in the sitemap generated by the rainlab.sitemap plugin). The posts page for these "empty" categories result in a 404 response (unhelpful in for a sitemap and confusing for users).