### PR TITLE
Update Blog Category slug in URL on language switch to match translation

### DIFF
--- a/components/Categories.php
+++ b/components/Categories.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Blog\Components;
 
+use Event;
 use Db;
 use Carbon\Carbon;
 use Cms\Classes\Page;
@@ -59,6 +60,23 @@ class Categories extends ComponentBase
     public function getCategoryPageOptions()
     {
         return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    public function init()
+    {
+        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) {
+            $newParams = $params;
+
+            if (isset($params['slug'])) {
+                $records = BlogCategory::transWhere('slug', $params['slug'], $oldLocale)->first();
+                if ($records) {
+                    $records->translateContext($newLocale);
+                    $newParams['slug'] = $records['slug'];
+                }
+            }
+
+            return $newParams;
+        });
     }
 
     public function onRun()


### PR DESCRIPTION
This pull request is solving problem of category slug parameters of URLs not being changed to their localised versions on language change invoked by LangPicker component. Also solved by this is the alternateHrefLangElements component of Rainlab.Translate plugin not returning correct category slug translations. Such issue can (depending on implementation of error handling) cause 404s, 500s or just simple 'Category not found' errors, not to mention SEO problems with bad and duplicate links.

To replicate the issue this PR is solving:
1. Create a simple OctoberCMS site with Rainlab.Blog and Rainlab.Translate plugins.
2. Create a few categories and their translations
3. Create a few posts and assign them to categories
4. Open page with category archive and try to switch languages using the language picker component.

Example result of switching between primary to secondary language:
- primary lang URL: domain.tld/en/blog/category/english-category-name
- secondary lang URL: domain.tld/cz/blog/category/czech-category-name
- result URL without this fix: domain.tld/**cz**/blog/category/**english**-category-name (results in 404)
- result URL with this fix: domain.tld/**cz**/blog/category/**czech**-category-name (intended result)

At first I thought it must be a problem with Rainlab.Translate (I saw issues like https://github.com/rainlab/translate-plugin/issues/227 and https://github.com/rainlab/translate-plugin/pull/244 and a lot more, as well as the pull request https://github.com/rainlab/translate-plugin/pull/341) that partialy pointed me to the right direction. After some more digging I checked the Post and Category components in Blog plugin and realized that this part is missing in Category component.

I have tested this on:
OctoberCMS: v1, build 473
Rainlab.Blog: 1.52
Rainlab.Translate: 1.9.2