### PR TITLE
[TASK] Add Preview CMS Page option

### DIFF
--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -6,6 +6,8 @@ use BackendMenu;
 use RainLab\Blog\Models\Post;
 use RainLab\Blog\Models\Settings as BlogSettings;
 use Backend\Classes\Controller;
+use Cms\Classes\Controller as CmsController;
+use Cms\Classes\Theme;
 
 /**
  * Posts
@@ -68,7 +70,18 @@ class Posts extends Controller
         $this->addCss('/plugins/rainlab/blog/assets/css/rainlab.blog-preview.css');
         $this->addJs('/plugins/rainlab/blog/assets/js/post-form.js');
 
-        return $this->asExtension('FormController')->update($recordId);
+        $result = $this->asExtension('FormController')->update($recordId);
+
+        // Set pageUrl
+        if (!empty($model = $this->vars['formModel'])) {
+            if (!empty($cmsPage = BlogSettings::get('preview_cms_page'))) {
+                $ctrl = new CmsController(Theme::getActiveTheme());
+                $model->setUrl($cmsPage, $ctrl);
+                $this->vars['pageUrl'] = $model->url;
+            }
+        }
+
+        return $result;
     }
 
     public function export()

--- a/controllers/posts/_post_toolbar.htm
+++ b/controllers/posts/_post_toolbar.htm
@@ -39,7 +39,7 @@
     <a
         href="<?= Url::to($pageUrl) ?>"
         target="_blank"
-        class="btn btn-primary oc-icon-crosshairs <?php if (!false): ?>hide oc-hide<?php endif ?>"
+        class="btn btn-primary oc-icon-crosshairs <?php if (empty($pageUrl)): ?>hide oc-hide<?php endif ?>"
         data-control="preview-button">
             <?= e(trans('rainlab.blog::lang.blog.preview')) ?>
     </a>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -28,6 +28,8 @@ return [
         'show_all_posts_comment' => 'Display both published and unpublished posts on the frontend to backend users',
         'use_legacy_editor_label' => 'Use the Legacy Markdown Editor',
         'use_legacy_editor_comment' => 'Enable the older version of the markdown editor when using October CMS v2 and above',
+        'preview_cms_page_label' => 'Preview CMS Page',
+        'preview_cms_page_comment' => 'Select a page to open for the Preview button',
         'tab_general' => 'General',
         'preview' => 'Preview'
     ],

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,5 +1,7 @@
 <?php namespace RainLab\Blog\Models;
 
+use Cms\Classes\Page as CmsPage;
+use Cms\Classes\Theme;
 use October\Rain\Database\Model;
 
 class Settings extends Model
@@ -15,4 +17,40 @@ class Settings extends Model
     public $rules = [
         'show_all_posts' => ['boolean'],
     ];
+
+    /**
+     * Get Preview CMS Page dropdown options
+     * 
+     * @return array
+     */
+    public function getPreviewCmsPageOptions()
+    {
+        $theme = Theme::getActiveTheme();
+
+        $pages = CmsPage::listInTheme($theme, true);
+        $result = [];
+
+        foreach ($pages as $page) {
+            if (!$page->hasComponent('blogPost')) {
+                continue;
+            }
+
+            /*
+             * Component must use a categoryPage filter with a routing parameter and post slug
+             * eg: categoryPage = "{{ :somevalue }}", slug = "{{ :somevalue }}"
+             */
+            $properties = $page->getComponentProperties('blogPost');
+            if (!isset($properties['categoryPage']) || !preg_match('/{{\s*:/', $properties['slug'])) {
+                continue;
+            }
+
+            $baseName = $page->getBaseFileName();
+            $pos = strrpos($baseName, '/');
+            $dir = $pos !== false ? substr($baseName, 0, $pos).' / ' : null;
+
+            $result[$baseName] = strlen($page->title) ? $dir.$page->title : $baseName;
+        }
+        
+        return $result;
+    }
 }

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -15,3 +15,10 @@ tabs:
             type: switch
             default: 0
             tab: rainlab.blog::lang.blog.tab_general
+
+        preview_cms_page:
+            span: auto
+            label: rainlab.blog::lang.blog.preview_cms_page_label
+            comment: rainlab.blog::lang.blog.preview_cms_page_comment
+            type: dropdown
+            tab: rainlab.blog::lang.blog.tab_general


### PR DESCRIPTION
Hello,

[as discussed](https://github.com/rainlab/blog-plugin/issues/568#issuecomment-1221237019), a PR for the Preview CMS option / button.

Tested with OctoberCMS v3.0.67 and v2.2.34.

~Sam.
